### PR TITLE
make batch processing possible, so I do not need to wait for all errors to be fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ To resolve an error via the API:
 
     Hoptoad::Error.update(1696170, :group => { :resolved => true})
 
+Recreate an error:
+
+    STDOUT.sync = true
+    Hoptoad::Notice.find_all_by_error_id(error_id) do |batch|
+      batch.each do |notice|
+        result = system "curl --silent '#{notice.request.url}' > /dev/null"
+        print (result ? '.' : 'F')
+      end
+    end
+
 Projects
 --------
 

--- a/lib/hoptoad-api/notice.rb
+++ b/lib/hoptoad-api/notice.rb
@@ -27,9 +27,12 @@ module Hoptoad
         end
         notice_stubs = hash.notices
 
-        notice_stubs.map do |notice|
-          notices << find(notice.id, error_id)
+        batch = notice_stubs.map do |notice|
+          find(notice.id, error_id)
         end
+        yield batch if block_given?
+        batch.each{|n| notices << n }
+
         break if notice_stubs.size < 30
         page += 1
       end

--- a/spec/hoptoad_api/notice_spec.rb
+++ b/spec/hoptoad_api/notice_spec.rb
@@ -23,6 +23,15 @@ describe Hoptoad::Notice do
     notices.size.should == 60
   end
 
+  it "yields batches" do
+    batches = []
+    notices = Hoptoad::Notice.find_all_by_error_id(1696171, :pages => 2) do |batch|
+      batches << batch
+    end
+    notices.size.should == 60
+    batches.map(&:size).should == [30,30]
+  end
+
   it "should find individual notices" do
     Hoptoad::Notice.find(1234, 1696170)
   end


### PR DESCRIPTION
``` Ruby
   STDOUT.sync = true
    Hoptoad::Notice.find_all_by_error_id(error_id) do |batch|
      batch.each do |notice|
        result = system "curl --silent '#{notice.request.url}' > /dev/null"
        print (result ? '.' : 'F')
      end
    end
```
