### PR TITLE
Reflect rename of errors to groups in airbrake routes

### DIFF
--- a/lib/airbrake-api/client.rb
+++ b/lib/airbrake-api/client.rb
@@ -57,7 +57,7 @@ module AirbrakeAPI
     # errors
 
     def unformatted_error_path(error_id)
-      "/errors/#{error_id}"
+      "/groups/#{error_id}"
     end
 
     def error_path(error_id)
@@ -65,7 +65,7 @@ module AirbrakeAPI
     end
 
     def errors_path
-      '/errors.xml'
+      '/groups.xml'
     end
 
     def update(error, options = {})
@@ -86,11 +86,11 @@ module AirbrakeAPI
     # notices
 
     def notice_path(notice_id, error_id)
-      "/errors/#{error_id}/notices/#{notice_id}.xml"
+      "/groups/#{error_id}/notices/#{notice_id}.xml"
     end
 
     def notices_path(error_id)
-      "/errors/#{error_id}/notices.xml"
+      "/groups/#{error_id}/notices.xml"
     end
 
     def notice(notice_id, error_id, options = {})

--- a/spec/airbrake_api/client_spec.rb
+++ b/spec/airbrake_api/client_spec.rb
@@ -206,19 +206,19 @@ describe AirbrakeAPI::Client do
     end
 
     it 'generates web urls for errors' do
-      @client.url_for(:errors).should eq('http://myapp.airbrake.io/errors')
+      @client.url_for(:errors).should eq('http://myapp.airbrake.io/groups')
     end
 
     it 'generates web urls for individual errors' do
-      @client.url_for(:error, 1696171).should eq('http://myapp.airbrake.io/errors/1696171')
+      @client.url_for(:error, 1696171).should eq('http://myapp.airbrake.io/groups/1696171')
     end
 
     it 'generates web urls for notices' do
-      @client.url_for(:notices, 1696171).should eq('http://myapp.airbrake.io/errors/1696171/notices')
+      @client.url_for(:notices, 1696171).should eq('http://myapp.airbrake.io/groups/1696171/notices')
     end
 
     it 'generates web urls for individual notices' do
-      @client.url_for(:notice, 123, 1696171).should eq('http://myapp.airbrake.io/errors/1696171/notices/123')
+      @client.url_for(:notice, 123, 1696171).should eq('http://myapp.airbrake.io/groups/1696171/notices/123')
     end
 
     it 'raises an exception when passed an unknown endpoint' do

--- a/spec/airbrake_api/error_spec.rb
+++ b/spec/airbrake_api/error_spec.rb
@@ -8,11 +8,11 @@ describe AirbrakeAPI::Error do
   end
 
   it "should have correct collection path" do
-    AirbrakeAPI::Error.collection_path.should == "/errors.xml"
+    AirbrakeAPI::Error.collection_path.should == "/groups.xml"
   end
 
   it "should generate correct error path given an id" do
-    AirbrakeAPI::Error.error_path(1234).should == "/errors/1234.xml"
+    AirbrakeAPI::Error.error_path(1234).should == "/groups/1234.xml"
   end
 
   describe '.find' do

--- a/spec/airbrake_api/notice_spec.rb
+++ b/spec/airbrake_api/notice_spec.rb
@@ -47,10 +47,10 @@ describe AirbrakeAPI::Notice do
   end
 
   it 'defines the notices path' do
-    AirbrakeAPI::Notice.all_path(1696170).should eq('/errors/1696170/notices.xml')
+    AirbrakeAPI::Notice.all_path(1696170).should eq('/groups/1696170/notices.xml')
   end
 
   it 'defines the an individual notices path' do
-    AirbrakeAPI::Notice.find_path(666, 1696170).should eq('/errors/1696170/notices/666.xml')
+    AirbrakeAPI::Notice.find_path(666, 1696170).should eq('/groups/1696170/notices/666.xml')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,25 +23,25 @@ def fixture_request(verb, url, file)
 end
 
 # errors
-fixture_request :get, 'http://myapp.airbrake.io/errors.xml?auth_token=abcdefg123456', 'errors.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors.xml?auth_token=abcdefg123456&page=2", 'paginated_errors.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
-fixture_request :put, 'http://myapp.airbrake.io/errors/1696170?auth_token=abcdefg123456', 'update_error.xml'
-fixture_request :get, 'https://anapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg', 'individual_error.xml'
+fixture_request :get, 'http://myapp.airbrake.io/groups.xml?auth_token=abcdefg123456', 'errors.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups.xml?auth_token=abcdefg123456&page=2", 'paginated_errors.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
+fixture_request :put, 'http://myapp.airbrake.io/groups/1696170?auth_token=abcdefg123456', 'update_error.xml'
+fixture_request :get, 'https://anapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg', 'individual_error.xml'
 
 # notices
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170/notices.xml?auth_token=abcdefg123456", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170/notices.xml?auth_token=abcdefg123456&page=1", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170/notices.xml?page=1&auth_token=abcdefg123456", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170/notices.xml?auth_token=abcdefg123456&page=2", 'paginated_notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170/notices/1234.xml?auth_token=abcdefg123456", 'individual_notice.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696170/notices/666.xml?auth_token=abcdefg123456", 'broken_notice.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696171/notices.xml?auth_token=abcdefg123456", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696171/notices.xml?auth_token=abcdefg123456&page=1", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696171/notices.xml?auth_token=abcdefg123456&page=2", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696171/notices.xml?auth_token=abcdefg123456&page=3", 'paginated_notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696171/notices/1234.xml?auth_token=abcdefg123456", 'notices.xml'
-fixture_request :get, "http://myapp.airbrake.io/errors/1696172/notices.xml?auth_token=abcdefg123456&page=1", 'unauthorized.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices.xml?auth_token=abcdefg123456", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices.xml?auth_token=abcdefg123456&page=1", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices.xml?page=1&auth_token=abcdefg123456", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices.xml?auth_token=abcdefg123456&page=2", 'paginated_notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices/1234.xml?auth_token=abcdefg123456", 'individual_notice.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices/666.xml?auth_token=abcdefg123456", 'broken_notice.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696171/notices.xml?auth_token=abcdefg123456", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696171/notices.xml?auth_token=abcdefg123456&page=1", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696171/notices.xml?auth_token=abcdefg123456&page=2", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696171/notices.xml?auth_token=abcdefg123456&page=3", 'paginated_notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696171/notices/1234.xml?auth_token=abcdefg123456", 'notices.xml'
+fixture_request :get, "http://myapp.airbrake.io/groups/1696172/notices.xml?auth_token=abcdefg123456&page=1", 'unauthorized.xml'
 
 # projects
 fixture_request :get, "http://myapp.airbrake.io/data_api/v1/projects.xml?auth_token=abcdefg123456", 'projects.xml'
@@ -51,5 +51,5 @@ fixture_request :get, "http://myapp.airbrake.io/projects/12345/deploys.xml?auth_
 fixture_request :get, "http://myapp.airbrake.io/projects/67890/deploys.xml?auth_token=abcdefg123456", 'empty_deploys.xml'
 
 # ssl responses
-fixture_request :get, "https://sslapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
-FakeWeb.register_uri(:get, "http://sslapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg123456", DEFAULTS.merge(:body => " ", :status => ["403", "Forbidden"]))
+fixture_request :get, "https://sslapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
+FakeWeb.register_uri(:get, "http://sslapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg123456", DEFAULTS.merge(:body => " ", :status => ["403", "Forbidden"]))


### PR DESCRIPTION
Sorry, I've deleted original fork, so I couldn't edit original pull-request therefore I've created a new one :)
