### PR TITLE
Update path to get the XML for a specific error

### DIFF
--- a/lib/airbrake-api/client.rb
+++ b/lib/airbrake-api/client.rb
@@ -58,7 +58,7 @@ module AirbrakeAPI
     # errors
 
     def unformatted_error_path(error_id)
-      "/groups/#{error_id}"
+      "/errors/#{error_id}"
     end
 
     def error_path(error_id)

--- a/spec/airbrake_api/client_spec.rb
+++ b/spec/airbrake_api/client_spec.rb
@@ -219,7 +219,7 @@ describe AirbrakeAPI::Client do
     end
 
     it 'generates web urls for individual errors' do
-      @client.url_for(:error, 1696171).should eq('http://myapp.airbrake.io/groups/1696171')
+      @client.url_for(:error, 1696171).should eq('http://myapp.airbrake.io/errors/1696171')
     end
 
     it 'generates web urls for notices' do

--- a/spec/airbrake_api/error_spec.rb
+++ b/spec/airbrake_api/error_spec.rb
@@ -12,7 +12,7 @@ describe AirbrakeAPI::Error do
   end
 
   it "should generate correct error path given an id" do
-    AirbrakeAPI::Error.error_path(1234).should == "/groups/1234.xml"
+    AirbrakeAPI::Error.error_path(1234).should == '/errors/1234.xml'
   end
 
   describe '.find' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,9 @@ end
 # errors
 fixture_request :get, 'http://myapp.airbrake.io/groups.xml?auth_token=abcdefg123456', 'errors.xml'
 fixture_request :get, "http://myapp.airbrake.io/groups.xml?auth_token=abcdefg123456&page=2", 'paginated_errors.xml'
-fixture_request :get, "http://myapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
-fixture_request :put, 'http://myapp.airbrake.io/groups/1696170?auth_token=abcdefg123456', 'update_error.xml'
-fixture_request :get, 'https://anapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg', 'individual_error.xml'
+fixture_request :get, 'http://myapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg123456', 'individual_error.xml'
+fixture_request :put, 'http://myapp.airbrake.io/errors/1696170?auth_token=abcdefg123456', 'update_error.xml'
+fixture_request :get, 'https://anapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg', 'individual_error.xml'
 
 # notices
 fixture_request :get, "http://myapp.airbrake.io/groups/1696170/notices.xml?auth_token=abcdefg123456", 'notices.xml'
@@ -51,5 +51,5 @@ fixture_request :get, "http://myapp.airbrake.io/projects/12345/deploys.xml?auth_
 fixture_request :get, "http://myapp.airbrake.io/projects/67890/deploys.xml?auth_token=abcdefg123456", 'empty_deploys.xml'
 
 # ssl responses
-fixture_request :get, "https://sslapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
-FakeWeb.register_uri(:get, "http://sslapp.airbrake.io/groups/1696170.xml?auth_token=abcdefg123456", DEFAULTS.merge(:body => " ", :status => ["403", "Forbidden"]))
+fixture_request :get, "https://sslapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg123456", 'individual_error.xml'
+FakeWeb.register_uri(:get, "http://sslapp.airbrake.io/errors/1696170.xml?auth_token=abcdefg123456", DEFAULTS.merge(:body => " ", :status => ["403", "Forbidden"]))


### PR DESCRIPTION
Hello!

Seems that AB has changed the URL address for a specific error. Now it's http://your_account.airbrake.io/errors/ERROR-ID.xml?auth_token=TOKEN (http://help.airbrake.io/kb/api-2/api-overview). 
It has `errors` instead of `groups`.
