### PR TITLE
add Configuration#middleware to customize middleware stack

### DIFF
--- a/lib/airbrake-api/client.rb
+++ b/lib/airbrake-api/client.rb
@@ -1,9 +1,5 @@
-require 'faraday_middleware'
 require 'parallel'
 require 'airbrake-api/core_ext/hash'
-require 'airbrake-api/middleware/scrub_response'
-require 'airbrake-api/middleware/raise_server_error'
-require 'airbrake-api/middleware/raise_response_error'
 
 module AirbrakeAPI
   class Client
@@ -171,12 +167,7 @@ module AirbrakeAPI
         :url => account_path,
       }
       @connection ||= Faraday.new(default_options.deep_merge(connection_options)) do |builder|
-        builder.use Faraday::Request::UrlEncoded
-        builder.use AirbrakeAPI::Middleware::RaiseResponseError
-        builder.use FaradayMiddleware::Mashify
-        builder.use FaradayMiddleware::ParseXml
-        builder.use AirbrakeAPI::Middleware::ScrubResponse
-        builder.use AirbrakeAPI::Middleware::RaiseServerError
+        middleware.each { |mw| builder.use *mw }
 
         builder.adapter adapter
       end

--- a/lib/airbrake-api/configuration.rb
+++ b/lib/airbrake-api/configuration.rb
@@ -1,4 +1,8 @@
 require 'airbrake-api/version'
+require 'faraday_middleware'
+require 'airbrake-api/middleware/scrub_response'
+require 'airbrake-api/middleware/raise_server_error'
+require 'airbrake-api/middleware/raise_response_error'
 
 module AirbrakeAPI
   module Configuration
@@ -8,13 +12,21 @@ module AirbrakeAPI
       :secure,
       :connection_options,
       :adapter,
-      :user_agent]
+      :user_agent,
+      :middleware]
 
     attr_accessor *VALID_OPTIONS_KEYS
 
     DEFAULT_ADAPTER     = :net_http
     DEFAULT_USER_AGENT  = "AirbrakeAPI Ruby Gem #{AirbrakeAPI::VERSION}"
     DEFAULT_CONNECTION_OPTIONS = {}
+    DEFAULT_MIDDLEWARE  = [
+      Faraday::Request::UrlEncoded,
+      AirbrakeAPI::Middleware::RaiseResponseError,
+      FaradayMiddleware::Mashify,
+      FaradayMiddleware::ParseXml,
+      AirbrakeAPI::Middleware::ScrubResponse,
+      AirbrakeAPI::Middleware::RaiseServerError]
 
     def self.extended(base)
       base.reset
@@ -24,6 +36,7 @@ module AirbrakeAPI
       @account    = options[:account] if options.has_key?(:account)
       @auth_token = options[:auth_token] if options.has_key?(:auth_token)
       @secure     = options[:secure] if options.has_key?(:secure)
+      @middleware = options[:middleware] if options.has_key?(:middleware)
       yield self if block_given?
       self
     end
@@ -49,6 +62,7 @@ module AirbrakeAPI
       @adapter    = DEFAULT_ADAPTER
       @user_agent = DEFAULT_USER_AGENT
       @connection_options = DEFAULT_CONNECTION_OPTIONS
+      @middleware = DEFAULT_MIDDLEWARE
     end
 
   end


### PR DESCRIPTION
Added a configuration option to customize used middleware to be able to e.g. add a local cache. Here is an example of how you could initialize customized middleware list. Notice that we can pass parameters to middleware components by specifying them in an array.

``` ruby
custom_mw =
[
  [FaradayMiddleware::Caching, ActiveSupport::Cache::FileStore.new(cache_path, ... ), 
      { :ignore_params => %w[auth_token] } ],
  Faraday::Response::Logger
]

AirbrakeAPI::Client.new(:middleware => AirbrakeAPI::Configuration::DEFAULT_MIDDLEWARE + custom_mw)
```
